### PR TITLE
Expose JSON RPC ports in Dockerfile

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -47,5 +47,5 @@ VOLUME /data
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-EXPOSE 8333 18333
+EXPOSE 8332 8333 18332 18333
 CMD ["bitcoind"]


### PR DESCRIPTION
Hi, would you mind exposing 2 additional ports for JSON RPC? Can be useful when testing with other tools that require Bitcoin RPC. Thanks.
