### PR TITLE
Add Bitcoin Core 0.14.2-uasfsegwit0.3

### DIFF
--- a/core/0.14.2-uasfsegwit0.3/Dockerfile
+++ b/core/0.14.2-uasfsegwit0.3/Dockerfile
@@ -1,0 +1,46 @@
+FROM debian:jessie
+
+RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+RUN set -ex \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
+	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+ENV BITCOIN_VERSION 0.14.2-uasfsegwit0.3
+ENV BITCOIN_URL https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/bitcoin-0.14.2-bip148_segwit0.3-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 668ba1ae6d54307878e1e02d396b96e0bb3829b71735cb1992910cadf861db1f
+ENV BITCOIN_ASC_URL https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/SHA256SUMS.asc
+ENV BITCOIN_PGP_KEY E463A93F5F3117EEDE6C7316BD02942421F4889F
+
+# install bitcoin binaries
+RUN set -ex \
+	&& BITCOIN_DIST=$(basename $BITCOIN_URL) \
+	&& wget -qO $BITCOIN_DIST $BITCOIN_URL \
+	&& echo "$BITCOIN_SHA256 $BITCOIN_DIST" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys $BITCOIN_PGP_KEY \
+	&& wget -qO bitcoin.asc $BITCOIN_ASC_URL \
+	&& gpg --verify bitcoin.asc \
+	&& tar -xzvf $BITCOIN_DIST -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm bitcoin*
+
+ENV BITCOIN_DATA /data
+RUN mkdir $BITCOIN_DATA \
+	&& chown bitcoin:bitcoin $BITCOIN_DATA \
+	&& ln -s $BITCOIN_DATA /home/bitcoin/.bitcoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333
+CMD ["bitcoind"]

--- a/core/0.14.2-uasfsegwit0.3/docker-entrypoint.sh
+++ b/core/0.14.2-uasfsegwit0.3/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 'test_bitcoin' ]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
+		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+		printtoconsole=1
+		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
+		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		EOF
+	fi
+
+	chown -R bitcoin "$BITCOIN_DATA"
+	exec gosu bitcoin "$@"
+fi
+
+exec "$@"

--- a/test.rb
+++ b/test.rb
@@ -2,17 +2,22 @@
 
 require "./update"
 
-def build_image(branch, version)
+def build_image(branch, version, opts)
   dir = File.join(branch, version)
   tag = "bitcoin-#{branch}:#{version}"
+
+  # some clients self-report a different formatted version
+  # so we allow this to be overridden in versions.yml
+  client_version = opts["client_version"] || version
+
   run "docker build -t #{tag} #{dir}"
-  run "docker run --rm #{tag} sh -c 'test -n \"$(bitcoind -version | grep \"version v#{version}\")\"'"
+  run "docker run --rm #{tag} sh -c 'test -n \"$(bitcoind -version | grep \"version v#{client_version}\")\"'"
 end
 
 if __FILE__ == $0
   load_versions.each do |branch, versions|
-    versions.each do |version, _|
-      build_image(branch, version)
+    versions.each do |version, opts|
+      build_image(branch, version, opts)
     end
   end
 end

--- a/versions.yml
+++ b/versions.yml
@@ -54,6 +54,12 @@ core:
     asc_url: https://bitcoin.org/bin/bitcoin-core-0.14.2/SHA256SUMS.asc
     key: 01EA5486DE18A882D4C2684590C8019E36C2E964
     sha256: 20acc6d5d5e0c4140387bc3445b8b3244d74c1c509bd98f62b4ee63bec31a92b
+  0.14.2-uasfsegwit0.3:
+    url: https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/bitcoin-0.14.2-bip148_segwit0.3-x86_64-linux-gnu.tar.gz
+    asc_url: https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/SHA256SUMS.asc
+    key: E463A93F5F3117EEDE6C7316BD02942421F4889F
+    sha256: 668ba1ae6d54307878e1e02d396b96e0bb3829b71735cb1992910cadf861db1f
+    client_version: 0.14.2.0-3a051b8
 
 classic:
   0.11.2.cl1:


### PR DESCRIPTION
Given that UASF SegWit does not seem to be advertising itself as a separate distribution of Bitcoin, and is more of a patch against Core, I think it's more appropriate to simply tag it as a version of Core.

There doesn't appear to be any consistent naming scheme for this release, so I'm going with `0.14.2-uasfsegwit0.3`. I also considered `0.14.2-bip148` which is probably more technically accurate, but less likely to be found by users interested in running this patch.

Replaces https://github.com/amacneil/docker-bitcoin/pull/17

cc @roshii