### PR TITLE
Allow Docker's default subnet for API call

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -4,8 +4,7 @@ RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget
 
 ENV BITCOIN_VERSION <%= version %>
 ENV BITCOIN_URL <%= url %>
@@ -27,6 +26,10 @@ RUN set -ex \
 <% end -%>
 	&& tar -xzvf $BITCOIN_DIST -C /usr/local --strip-components=1 --exclude=*-qt \
 	&& rm bitcoin*
+
+RUN apt-get autoremove -qqy --purge ca-certificates wget gpg dirmngr \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV BITCOIN_DATA /data
 RUN mkdir $BITCOIN_DATA \

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,10 +1,11 @@
-FROM debian:stable
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV BITCOIN_VERSION <%= version %>
 ENV BITCOIN_URL <%= url %>
@@ -26,10 +27,6 @@ RUN set -ex \
 <% end -%>
 	&& tar -xzvf $BITCOIN_DIST -C /usr/local --strip-components=1 --exclude=*-qt \
 	&& rm bitcoin*
-
-RUN apt-get autoremove -qqy --purge ca-certificates wget gpg dirmngr \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
 
 ENV BITCOIN_DATA /data
 RUN mkdir $BITCOIN_DATA \

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stable
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION <%= version %>
 ENV BITCOIN_URL <%= url %>

--- a/btc1/1.14.3/Dockerfile
+++ b/btc1/1.14.3/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.14.3
 ENV BITCOIN_URL https://github.com/btc1/bitcoin/releases/download/v1.14.3/bitcoin-1.14.3-x86_64-linux-gnu.tar.gz

--- a/btc1/1.14.3/docker-entrypoint.sh
+++ b/btc1/1.14.3/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/0.11.2.cl1/Dockerfile
+++ b/classic/0.11.2.cl1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.2.cl1
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v0.11.2.cl1/bitcoin-0.11.2-linux64.tar.gz

--- a/classic/0.11.2.cl1/docker-entrypoint.sh
+++ b/classic/0.11.2.cl1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/0.12.0cl1/Dockerfile
+++ b/classic/0.12.0cl1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.12.0cl1
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v0.12.0cl1/bitcoin-0.12.0-linux64.tar.gz

--- a/classic/0.12.0cl1/docker-entrypoint.sh
+++ b/classic/0.12.0cl1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/0.12.1cl1/Dockerfile
+++ b/classic/0.12.1cl1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.12.1cl1
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v0.12.1cl1/bitcoin-0.12.1-linux64.tar.gz

--- a/classic/0.12.1cl1/docker-entrypoint.sh
+++ b/classic/0.12.1cl1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/1.1.0/Dockerfile
+++ b/classic/1.1.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.1.0
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v1.1.0/bitcoin-1.1.0-linux64.tar.gz

--- a/classic/1.1.0/docker-entrypoint.sh
+++ b/classic/1.1.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/1.1.1/Dockerfile
+++ b/classic/1.1.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.1.1
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v1.1.1/bitcoin-1.1.1-linux64.tar.gz

--- a/classic/1.1.1/docker-entrypoint.sh
+++ b/classic/1.1.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/1.2.0/Dockerfile
+++ b/classic/1.2.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.2.0
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v1.2.0/bitcoin-1.2.0-linux64.tar.gz

--- a/classic/1.2.0/docker-entrypoint.sh
+++ b/classic/1.2.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/1.2.1/Dockerfile
+++ b/classic/1.2.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.2.1
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v1.2.1/bitcoin-1.2.1-linux64.tar.gz

--- a/classic/1.2.1/docker-entrypoint.sh
+++ b/classic/1.2.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/1.2.2/Dockerfile
+++ b/classic/1.2.2/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.2.2
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v1.2.2/bitcoin-1.2.2-linux64.tar.gz

--- a/classic/1.2.2/docker-entrypoint.sh
+++ b/classic/1.2.2/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/classic/1.2.3/Dockerfile
+++ b/classic/1.2.3/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.2.3
 ENV BITCOIN_URL https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v1.2.3/bitcoin-1.2.3-linux64.tar.gz

--- a/classic/1.2.3/docker-entrypoint.sh
+++ b/classic/1.2.3/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.10.3/Dockerfile
+++ b/core/0.10.3/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.10.3
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.10.3/bitcoin-0.10.3-linux64.tar.gz

--- a/core/0.10.3/docker-entrypoint.sh
+++ b/core/0.10.3/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.11.1/Dockerfile
+++ b/core/0.11.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.1
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.11.1/bitcoin-0.11.1-linux64.tar.gz

--- a/core/0.11.1/docker-entrypoint.sh
+++ b/core/0.11.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.11.2/Dockerfile
+++ b/core/0.11.2/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.2
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.11.2/bitcoin-0.11.2-linux64.tar.gz

--- a/core/0.11.2/docker-entrypoint.sh
+++ b/core/0.11.2/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.12.0/Dockerfile
+++ b/core/0.12.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.12.0
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.12.0/bitcoin-0.12.0-linux64.tar.gz

--- a/core/0.12.0/docker-entrypoint.sh
+++ b/core/0.12.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.12.1/Dockerfile
+++ b/core/0.12.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.12.1
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.12.1/bitcoin-0.12.1-linux64.tar.gz

--- a/core/0.12.1/docker-entrypoint.sh
+++ b/core/0.12.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.13.0/Dockerfile
+++ b/core/0.13.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.13.0
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.13.0/bitcoin-0.13.0-x86_64-linux-gnu.tar.gz

--- a/core/0.13.0/docker-entrypoint.sh
+++ b/core/0.13.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.13.1/Dockerfile
+++ b/core/0.13.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.13.1
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.13.1/bitcoin-0.13.1-x86_64-linux-gnu.tar.gz

--- a/core/0.13.1/docker-entrypoint.sh
+++ b/core/0.13.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.13.2/Dockerfile
+++ b/core/0.13.2/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.13.2
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.13.2/bitcoin-0.13.2-x86_64-linux-gnu.tar.gz

--- a/core/0.13.2/docker-entrypoint.sh
+++ b/core/0.13.2/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.14.0/Dockerfile
+++ b/core/0.14.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.14.0
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.14.0/bitcoin-0.14.0-x86_64-linux-gnu.tar.gz

--- a/core/0.14.0/docker-entrypoint.sh
+++ b/core/0.14.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.14.1/Dockerfile
+++ b/core/0.14.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.14.1
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.14.1/bitcoin-0.14.1-x86_64-linux-gnu.tar.gz

--- a/core/0.14.1/docker-entrypoint.sh
+++ b/core/0.14.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.14.2-uasfsegwit0.3/Dockerfile
+++ b/core/0.14.2-uasfsegwit0.3/Dockerfile
@@ -4,8 +4,7 @@ RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget
 
 ENV BITCOIN_VERSION 0.14.2-uasfsegwit0.3
 ENV BITCOIN_URL https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/bitcoin-0.14.2-bip148_segwit0.3-x86_64-linux-gnu.tar.gz
@@ -24,6 +23,10 @@ RUN set -ex \
 	&& tar -xzvf $BITCOIN_DIST -C /usr/local --strip-components=1 --exclude=*-qt \
 	&& rm bitcoin*
 
+RUN apt-get autoremove -qqy --purge ca-certificates wget gpg dirmngr \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+	
 ENV BITCOIN_DATA /data
 RUN mkdir $BITCOIN_DATA \
 	&& chown bitcoin:bitcoin $BITCOIN_DATA \

--- a/core/0.14.2-uasfsegwit0.3/Dockerfile
+++ b/core/0.14.2-uasfsegwit0.3/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stable
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.14.2-uasfsegwit0.3
 ENV BITCOIN_URL https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/bitcoin-0.14.2-bip148_segwit0.3-x86_64-linux-gnu.tar.gz

--- a/core/0.14.2-uasfsegwit0.3/Dockerfile
+++ b/core/0.14.2-uasfsegwit0.3/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:stable
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qy --no-install-recommends ca-certificates dirmngr gosu gpg wget
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV BITCOIN_VERSION 0.14.2-uasfsegwit0.3
 ENV BITCOIN_URL https://uasf.bitcoinreminder.com/core-0.14.2-uasfsegwit0.3/bitcoin-0.14.2-bip148_segwit0.3-x86_64-linux-gnu.tar.gz
@@ -23,10 +24,6 @@ RUN set -ex \
 	&& tar -xzvf $BITCOIN_DIST -C /usr/local --strip-components=1 --exclude=*-qt \
 	&& rm bitcoin*
 
-RUN apt-get autoremove -qqy --purge ca-certificates wget gpg dirmngr \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
-	
 ENV BITCOIN_DATA /data
 RUN mkdir $BITCOIN_DATA \
 	&& chown bitcoin:bitcoin $BITCOIN_DATA \

--- a/core/0.14.2-uasfsegwit0.3/docker-entrypoint.sh
+++ b/core/0.14.2-uasfsegwit0.3/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/core/0.14.2/Dockerfile
+++ b/core/0.14.2/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.14.2
 ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.14.2/bitcoin-0.14.2-x86_64-linux-gnu.tar.gz

--- a/core/0.14.2/docker-entrypoint.sh
+++ b/core/0.14.2/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/0.11.2/Dockerfile
+++ b/unlimited/0.11.2/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.2
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-0.11.2-linux64.tar.gz

--- a/unlimited/0.11.2/docker-entrypoint.sh
+++ b/unlimited/0.11.2/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/0.12.0/Dockerfile
+++ b/unlimited/0.12.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.12.0
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-0.12.0-linux64.tar.gz

--- a/unlimited/0.12.0/docker-entrypoint.sh
+++ b/unlimited/0.12.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/0.12.1/Dockerfile
+++ b/unlimited/0.12.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.12.1
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-0.12.1-linux64.tar.gz

--- a/unlimited/0.12.1/docker-entrypoint.sh
+++ b/unlimited/0.12.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/1.0.0.1/Dockerfile
+++ b/unlimited/1.0.0.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.0.0.1
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-1.0.0.1-linux64.tar.gz

--- a/unlimited/1.0.0.1/docker-entrypoint.sh
+++ b/unlimited/1.0.0.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/1.0.1.0/Dockerfile
+++ b/unlimited/1.0.1.0/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.0.1.0
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-1.0.1-linux64.tar.gz

--- a/unlimited/1.0.1.0/docker-entrypoint.sh
+++ b/unlimited/1.0.1.0/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/1.0.1.1/Dockerfile
+++ b/unlimited/1.0.1.1/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.0.1.1
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-1.0.1.1-linux64.tar.gz

--- a/unlimited/1.0.1.1/docker-entrypoint.sh
+++ b/unlimited/1.0.1.1/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/unlimited/1.0.1.2/Dockerfile
+++ b/unlimited/1.0.1.2/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 1.0.1.2
 ENV BITCOIN_URL https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-1.0.1.2-linux64.tar.gz

--- a/unlimited/1.0.1.2/docker-entrypoint.sh
+++ b/unlimited/1.0.1.2/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/xt/0.11.0B/Dockerfile
+++ b/xt/0.11.0B/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.0B
 ENV BITCOIN_URL https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11B/bitcoin-xt-0.11.0-B-linux64.tar.gz

--- a/xt/0.11.0B/docker-entrypoint.sh
+++ b/xt/0.11.0B/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/xt/0.11.0C/Dockerfile
+++ b/xt/0.11.0C/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.0C
 ENV BITCOIN_URL https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11C/bitcoin-xt-0.11.0-C-linux64.tar.gz

--- a/xt/0.11.0C/docker-entrypoint.sh
+++ b/xt/0.11.0C/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/xt/0.11.0D/Dockerfile
+++ b/xt/0.11.0D/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.0D
 ENV BITCOIN_URL https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11D/bitcoin-xt-0.11.0-D-linux64.tar.gz

--- a/xt/0.11.0D/docker-entrypoint.sh
+++ b/xt/0.11.0D/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/xt/0.11.0E/Dockerfile
+++ b/xt/0.11.0E/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.0E
 ENV BITCOIN_URL https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11E/bitcoin-xt-0.11.0-E-linux64.tar.gz

--- a/xt/0.11.0E/docker-entrypoint.sh
+++ b/xt/0.11.0E/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 

--- a/xt/0.11.0F/Dockerfile
+++ b/xt/0.11.0F/Dockerfile
@@ -1,20 +1,11 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates wget \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
 	&& rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN set -ex \
-	&& gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& wget -qO /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-	&& wget -qO /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
 
 ENV BITCOIN_VERSION 0.11.0F
 ENV BITCOIN_URL https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11F/bitcoin-xt-0.11.0-F-linux64.tar.gz

--- a/xt/0.11.0F/docker-entrypoint.sh
+++ b/xt/0.11.0F/docker-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 		printtoconsole=1
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+		# Allow Docker's default subnet for API call
+		rpcallowip=172.17.0.0/16
 		EOF
 	fi
 


### PR DESCRIPTION
This allows one to use bitcoin-cli call against bitcoind running in a container with default Docker's settings