### PR TITLE
Enable RPC access by default

### DIFF
--- a/btc1/1.14.3/docker-entrypoint.sh
+++ b/btc1/1.14.3/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/0.11.2.cl1/docker-entrypoint.sh
+++ b/classic/0.11.2.cl1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/0.12.0cl1/docker-entrypoint.sh
+++ b/classic/0.12.0cl1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/0.12.1cl1/docker-entrypoint.sh
+++ b/classic/0.12.1cl1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/1.1.0/docker-entrypoint.sh
+++ b/classic/1.1.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/1.1.1/docker-entrypoint.sh
+++ b/classic/1.1.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/1.2.0/docker-entrypoint.sh
+++ b/classic/1.2.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/1.2.1/docker-entrypoint.sh
+++ b/classic/1.2.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/1.2.2/docker-entrypoint.sh
+++ b/classic/1.2.2/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/classic/1.2.3/docker-entrypoint.sh
+++ b/classic/1.2.3/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.10.3/docker-entrypoint.sh
+++ b/core/0.10.3/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.11.1/docker-entrypoint.sh
+++ b/core/0.11.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.11.2/docker-entrypoint.sh
+++ b/core/0.11.2/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.12.0/docker-entrypoint.sh
+++ b/core/0.12.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.12.1/docker-entrypoint.sh
+++ b/core/0.12.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.13.0/docker-entrypoint.sh
+++ b/core/0.13.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.13.1/docker-entrypoint.sh
+++ b/core/0.13.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.13.2/docker-entrypoint.sh
+++ b/core/0.13.2/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.14.0/docker-entrypoint.sh
+++ b/core/0.14.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.14.1/docker-entrypoint.sh
+++ b/core/0.14.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.14.2-uasfsegwit0.3/docker-entrypoint.sh
+++ b/core/0.14.2-uasfsegwit0.3/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.14.2-uasfsegwit1.0/docker-entrypoint.sh
+++ b/core/0.14.2-uasfsegwit1.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/core/0.14.2/docker-entrypoint.sh
+++ b/core/0.14.2/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/0.11.2/docker-entrypoint.sh
+++ b/unlimited/0.11.2/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/0.12.0/docker-entrypoint.sh
+++ b/unlimited/0.12.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/0.12.1/docker-entrypoint.sh
+++ b/unlimited/0.12.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/1.0.0.1/docker-entrypoint.sh
+++ b/unlimited/1.0.0.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/1.0.1.0/docker-entrypoint.sh
+++ b/unlimited/1.0.1.0/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/1.0.1.1/docker-entrypoint.sh
+++ b/unlimited/1.0.1.1/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/unlimited/1.0.1.2/docker-entrypoint.sh
+++ b/unlimited/1.0.1.2/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/xt/0.11.0B/docker-entrypoint.sh
+++ b/xt/0.11.0B/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/xt/0.11.0C/docker-entrypoint.sh
+++ b/xt/0.11.0C/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/xt/0.11.0D/docker-entrypoint.sh
+++ b/xt/0.11.0D/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/xt/0.11.0E/docker-entrypoint.sh
+++ b/xt/0.11.0E/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF

--- a/xt/0.11.0F/docker-entrypoint.sh
+++ b/xt/0.11.0F/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [ "$1" = 'bitcoin-cli' -o "$1" = 'bitcoin-tx' -o "$1" = 'bitcoind' -o "$1" = 
 	if [ ! -s "$BITCOIN_DATA/bitcoin.conf" ]; then
 		cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
 		printtoconsole=1
+		rpcallowip=::/0
 		rpcpassword=${BITCOIN_RPC_PASSWORD:-password}
 		rpcuser=${BITCOIN_RPC_USER:-bitcoin}
 		EOF


### PR DESCRIPTION
Currently we use the default setting for `rpcallowip`, which means that you can only interact with bitcoind from 127.0.0.1. This does not make sense when using container networking, because the container is running on a private network and you are unlikely to run commands against it from the same host (except when using host networking). Even if users exposed this port to the host, they would not be able to connect or run `bitcoin-cli` against it, because `bitcoind` is running inside a container with a different IP.

This change opens the RPC port up to any host. In reality this means that only containers on the same user defined network will be able to access it, or if users expose port 8332 to the host they will also be able to access it.

I realize that the bitcoin documentation specifically recommends against this setting, however I think the above justification makes more sense in the context of container networking. There is also precedence for opening ports to the world by default in docker images (the default `postgres` and `redis` images do the same thing, with similar security implications).

Since this PR only changes our default `bitcoin.conf` file, it will not affect existing users with a persisted data volume.

The downside to this change is that users are more likely to accidentally expose the RPC interface on a public network (e.g. by mapping port 8332 to the host, or by using host networking). As stated above this is no different than other official docker images. However, for this reason I have not included any examples of mapping ports or host networking in the readme changes, instead suggesting methods which keep the RPC port internal.

Closes https://github.com/amacneil/docker-bitcoin/issues/2 https://github.com/amacneil/docker-bitcoin/pull/22